### PR TITLE
Update configure options for freetype and jpeg

### DIFF
--- a/Formula/amp-php@7.4.rb
+++ b/Formula/amp-php@7.4.rb
@@ -127,14 +127,14 @@ class AmpPhpAT74 < Formula
       --with-ffi
       --with-fpm-user=_www
       --with-fpm-group=_www
-      --with-freetype-dir=#{Formula["freetype"].opt_prefix}
+      --with-freetype
       --with-gd
       --with-gettext=#{Formula["gettext"].opt_prefix}
       --with-gmp=#{Formula["gmp"].opt_prefix}
       --with-iconv#{headers_path}
       --with-jpeg
       --with-icu-dir=#{Formula["icu4c"].opt_prefix}
-      --with-jpeg-dir=#{Formula["jpeg"].opt_prefix}
+      --with-jpeg
       --with-kerberos#{headers_path}
       --with-layout=GNU
       --with-ldap=#{Formula["openldap"].opt_prefix}


### PR DESCRIPTION
Seems 7.4 does not support args for `--with-freetype-dir` or `--with-jpeg-dir` and uses a shortened version without an arg value

Not totally down with the homebrew setup so not sure if this is enough to make it work. Surprised given the args are not supported that the build actually works with this config currently but 🤷 

Some slightly conflicting sources:

https://www.php.net/manual/en/image.installation.php `To enable support for FreeType 2 add --with-freetype-dir=DIR . As of PHP 7.4.0 use --with-freetype instead, which relies on pkg-config.` - the advice on this page seems to conflict with anecdotal evidence from the web of people trying to configure `--with-jpeg`

Anecdotal:

https://github.com/docker-library/php/issues/912
https://www.howtoforge.com/tutorial/how-to-compile-and-install-php-7.4-on-ubuntu-18-04/


Test:
`brew reinstall --build-from-source ./src/homebrew-php/Formula/amp-php@7.4.rb`

```
php -i | grep "FreeType"                   
FreeType Support => enabled
FreeType Linkage => with freetype
FreeType Version => 2.10.1```