### PR TITLE
Fix php 74 xdebug ini after upgrade

### DIFF
--- a/Abstract/abstract-php-extension.rb
+++ b/Abstract/abstract-php-extension.rb
@@ -165,6 +165,12 @@ EOS
     config_scandir_path / config_filename
   end
 
+  def unlink_config_file
+    if config_filepath.file?
+        config_filepath.unlink if config_filepath.exist?
+    end
+  end
+
   def write_config_file
     if config_filepath.file?
       inreplace config_filepath do |s|

--- a/Formula/amp-php@7.4-xdebug.rb
+++ b/Formula/amp-php@7.4-xdebug.rb
@@ -39,6 +39,7 @@ class AmpPhpAT74Xdebug < AbstractPhp74Extension
                           "--enable-xdebug"
     system "make"
     prefix.install "modules/xdebug.so"
+    unlink_config_file
     write_config_file if build.with? "config-file"
   end
 end

--- a/Formula/amp-php@8.1-xdebug.rb
+++ b/Formula/amp-php@8.1-xdebug.rb
@@ -39,6 +39,7 @@ class AmpPhpAT81Xdebug < AbstractPhp81Extension
                           "--enable-xdebug"
     system "make"
     prefix.install "modules/xdebug.so"
+    unlink_config_file
     write_config_file if build.with? "config-file"
   end
 end


### PR DESCRIPTION
Introduced in https://github.com/AmpersandHQ/homebrew-php/pull/12/

when the config definition was upgraded for the major version bump but old existing `.ini`  files would not be updated

We can manually delete the existing ini file for `amp-php@7.4-xdebug` when it is installing, allowing us to write a new correct one

Fixes this error which prevents xdebug working
```
Xdebug: [Config] The setting 'xdebug.remote_enable' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_enable (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
Xdebug: [Config] The setting 'xdebug.remote_port' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_port (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
```