### PR TITLE
Update Xdebug to 3.1 for PHP7.2 and PHP7.3

### DIFF
--- a/Formula/amp-php@7.2-xdebug.rb
+++ b/Formula/amp-php@7.2-xdebug.rb
@@ -4,9 +4,9 @@ class AmpPhpAT72Xdebug < AbstractPhp72Extension
   init
   desc "Provides debugging and profiling capabilities."
   homepage "https://xdebug.org"
-  url "https://xdebug.org/files/xdebug-2.6.0.tgz"
-  mirror "https://github.com/AmpersandHQ/homebrew-php/raw/master/files/xdebug-2.6.0.tgz"
-  sha256 "b5264cc03bf68fcbb04b97229f96dca505d7b87ec2fb3bd4249896783d29cbdc"
+  url "https://xdebug.org/files/xdebug-3.1.4.tgz"
+  mirror "https://github.com/AmpersandHQ/homebrew-php/raw/master/files/xdebug-3.1.4.tgz"
+  sha256 "4195926f9f6c4e802ff749bb2ca85ac50636719a72e5389e372e35ef523505f9"
   head "https://github.com/xdebug/xdebug.git"
 
   def extension_type
@@ -17,14 +17,18 @@ class AmpPhpAT72Xdebug < AbstractPhp72Extension
     <<~EOS
       [#{extension}]
       #{extension_type}="#{module_path}"
-      xdebug.remote_enable=1
-      xdebug.remote_port=9010
+      xdebug.mode=debug
+      xdebug.client_port=9010
+      xdebug.idekey=PHPSTORM
       EOS
   rescue StandardError
     nil
   end
 
   def install
+    system "pwd"
+    system "ls -lasth"
+
     Dir.chdir "xdebug-#{version}" unless build.head?
 
     safe_phpize

--- a/Formula/amp-php@7.3-xdebug.rb
+++ b/Formula/amp-php@7.3-xdebug.rb
@@ -4,9 +4,9 @@ class AmpPhpAT73Xdebug < AbstractPhp73Extension
   init
   desc "Provides debugging and profiling capabilities."
   homepage "https://xdebug.org"
-  url "https://xdebug.org/files/xdebug-2.7.2.tgz"
-  mirror "https://github.com/AmpersandHQ/homebrew-php/raw/master/files/xdebug-2.7.2.tgz"
-  sha256 "b0f3283aa185c23fcd0137c3aaa58554d330995ef7a3421e983e8d018b05a4a6"
+  url "https://xdebug.org/files/xdebug-3.1.4.tgz"
+  mirror "https://github.com/AmpersandHQ/homebrew-php/raw/master/files/xdebug-3.1.4.tgz"
+  sha256 "4195926f9f6c4e802ff749bb2ca85ac50636719a72e5389e372e35ef523505f9"
   head "https://github.com/xdebug/xdebug.git"
 
   def extension_type
@@ -17,14 +17,18 @@ class AmpPhpAT73Xdebug < AbstractPhp73Extension
     <<~EOS
       [#{extension}]
       #{extension_type}="#{module_path}"
-      xdebug.remote_enable=1
-      xdebug.remote_port=9010
+      xdebug.mode=debug
+      xdebug.client_port=9010
+      xdebug.idekey=PHPSTORM
       EOS
   rescue StandardError
     nil
   end
 
   def install
+    system "pwd"
+    system "ls -lasth"
+
     Dir.chdir "xdebug-#{version}" unless build.head?
 
     safe_phpize


### PR DESCRIPTION
### Description

Update Xdebug to latest compatible version for PHP7.2 & 7.3. Similar to https://github.com/AmpersandHQ/homebrew-php/pull/12

Ref: https://xdebug.org/docs/compat

![image](https://user-images.githubusercontent.com/22290866/211586981-c50cc37d-02f1-4607-886b-33b982b67b2b.png)

### Local screenshots
```
PHP 7.2.34 (cli) (built: Jan 10 2023 15:01:02) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Xdebug v3.1.4, Copyright (c) 2002-2022, by Derick Rethans
```

```
PHP 7.3.3 (cli) (built: Oct  3 2022 09:11:33) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.3, Copyright (c) 1998-2018 Zend Technologies
    with Xdebug v3.1.4, Copyright (c) 2002-2022, by Derick Rethans
```
