### PR TITLE
Fix extension install

### DIFF
--- a/Abstract/abstract-php-extension.rb
+++ b/Abstract/abstract-php-extension.rb
@@ -16,27 +16,6 @@ class InvalidPhpizeError < RuntimeError
 end
 
 class AbstractPhpExtension < Formula
-  def initialize(*)
-    super
-
-    if build.without? "homebrew-php"
-      installed_php_version = nil
-      i = IO.popen("#{phpize} -v")
-      out = i.readlines.join("")
-      i.close
-      { 53 => 20090626, 54 => 20100412, 55 => 20121113, 56 => 20131106, 70 => 20151012, 71 => 20160303, 72 => 20170718 }.each do |v, api|
-        installed_php_version = v.to_s if out.match(/#{api}/)
-      end
-
-      raise UnsupportedPhpApiError if installed_php_version.nil?
-
-      required_php_version = php_branch.sub(".", "").to_s
-      unless installed_php_version == required_php_version
-        raise InvalidPhpizeError.new(installed_php_version, required_php_version)
-      end
-    end
-  end
-
   def self.init
     depends_on "autoconf" => :build
 


### PR DESCRIPTION
This extension class was ported from the ancient homebrew-php which no longer exists, so i'm guessing this way of managing the extension was a catch all just in case you didnt have a version of php readily installed.

we definitely do, its part of this homebrew-php stuff. so just remove this extra catch.

Best guess is a recent change in https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula.rb caused this break.

## Before
```
$ brew reinstall amp-php@7.4-xdebug 
```
```bash
Error: wrong number of arguments (given 4, expected 3)
Please report this issue:
  https://docs.brew.sh/Troubleshooting
Warning: Removed Sorbet lines from backtrace!
Rerun with --verbose to see the original backtrace
/opt/homebrew/Library/Homebrew/formula.rb:204:in `initialize'
/opt/homebrew/Library/Taps/ampersandhq/homebrew-php/Abstract/abstract-php-extension.rb:20:in `initialize'
/opt/homebrew/Library/Homebrew/formulary.rb:498:in `new'
/opt/homebrew/Library/Homebrew/formulary.rb:498:in `get_formula'
/opt/homebrew/Library/Homebrew/formulary.rb:738:in `factory'
/opt/homebrew/Library/Homebrew/cli/parser.rb:656:in `block in formulae'
/opt/homebrew/Library/Homebrew/cli/parser.rb:652:in `map'
/opt/homebrew/Library/Homebrew/cli/parser.rb:652:in `formulae'
/opt/homebrew/Library/Homebrew/cli/parser.rb:324:in `parse'
/opt/homebrew/Library/Homebrew/cmd/reinstall.rb:112:in `reinstall'
/opt/homebrew/Library/Homebrew/brew.rb:86:in `<main>'
```

## After

```
$ brew reinstall amp-php@7.4-xdebug
```

```bash
==> Fetching ampersandhq/php/amp-php@7.4-xdebug
==> Downloading https://xdebug.org/files/xdebug-3.1.4.tgz
Already downloaded: /Users/lukerodgers/Library/Caches/Homebrew/downloads/dcb7348b893ace484a590d31ebdd7b96a94bda912467dc85d52eabd2ed561032--xdebug-3.1.4.tgz
==> Reinstalling ampersandhq/php/amp-php@7.4-xdebug
Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Settings.

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 14.3.

==> pwd
==> ls -lasth
/opt/homebrew/Library/Taps/ampersandhq/homebrew-php/Formula/amp-php@7.4-xdebug.rb:32: warning: conflicting chdir during another chdir block
==> /opt/homebrew/opt/amp-php@7.4/bin/phpize
==> ./configure --with-php-config=/opt/homebrew/opt/amp-php@7.4/bin/php-config --enable-xdebug
==> make
==> Caveats
To finish installing xdebug for PHP 7.4:
  * /opt/homebrew/etc/php/7.4/conf.d/ext-xdebug.ini was created,
    do not forget to remove it upon extension removal.
  * Validate installation via one of the following methods:
  *
  * Using PHP from a webserver:
  * - Restart your webserver.
  * - Write a PHP page that calls "phpinfo();"
  * - Load it in a browser and look for the info on the xdebug module.
  * - If you see it, you have been successful!
  *
  * Using PHP from the command line:
  * - Run `php -i "(command-line 'phpinfo()')"`
  * - Look for the info on the xdebug module.
  * - If you see it, you have been successful!
==> Summary
🍺  /opt/homebrew/Cellar/amp-php@7.4-xdebug/3.1.4: 3 files, 320.0KB, built in 17 seconds
==> Running `brew cleanup amp-php@7.4-xdebug`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```