### PR TITLE
Add workaround for Xcode 15.3

### DIFF
--- a/Formula/amp-php@5.6.rb
+++ b/Formula/amp-php@5.6.rb
@@ -40,6 +40,12 @@ class AmpPhpAT56 < Formula
     # Ensure that libxml2 will be detected correctly in older MacOS
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
 
+    # Work around for building with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
+      ENV.append "CFLAGS", "-Wno-implicit-int"
+    end
+
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     # See https://github.com/Homebrew/homebrew-core/pull/61828/

--- a/Formula/amp-php@7.0.rb
+++ b/Formula/amp-php@7.0.rb
@@ -41,6 +41,13 @@ class AmpPhpAT70 < Formula
     # Ensure that libxml2 will be detected correctly in older MacOS
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
 
+    # Work around for building with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
+      ENV.append "LDFLAGS", "-lresolv"
+      inreplace "main/reentrancy.c", "readdir_r(dirp, entry)", "readdir_r(dirp, entry, result)"
+    end
+
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     # See https://github.com/Homebrew/homebrew-core/pull/61828/
@@ -422,6 +429,24 @@ class AmpPhpAT70 < Formula
 end
 
 __END__
+diff --git a/configure.in b/configure.in
+index 7ba3bc05a5..279230fa80 100644
+--- a/configure.in
++++ b/configure.in
+@@ -60,7 +60,13 @@ AH_BOTTOM([
+ #endif
+
+ #if ZEND_BROKEN_SPRINTF
++#ifdef __cplusplus
++extern "C" {
++#endif
+ int zend_sprintf(char *buffer, const char *format, ...);
++#ifdef __cplusplus
++}
++#endif
+ #else
+ # define zend_sprintf sprintf
+ #endif
 diff --git a/acinclude.m4 b/acinclude.m4
 index 168c465f8d..6c087d152f 100644
 --- a/acinclude.m4

--- a/Formula/amp-php@7.1.rb
+++ b/Formula/amp-php@7.1.rb
@@ -42,6 +42,13 @@ class AmpPhpAT71 < Formula
     # Ensure that libxml2 will be detected correctly in older MacOS
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
 
+    # Work around for building with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
+      ENV.append "LDFLAGS", "-lresolv"
+      inreplace "main/reentrancy.c", "readdir_r(dirp, entry)", "readdir_r(dirp, entry, result)"
+    end
+
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     # See https://github.com/Homebrew/homebrew-core/pull/61828/
@@ -299,6 +306,24 @@ class AmpPhpAT71 < Formula
 end
 
 __END__
+diff --git a/configure.in b/configure.in
+index cd8b8794f0..b72464f020 100644
+--- a/configure.in
++++ b/configure.in
+@@ -60,7 +60,13 @@ AH_BOTTOM([
+ #endif
+
+ #if ZEND_BROKEN_SPRINTF
++#ifdef __cplusplus
++extern "C" {
++#endif
+ int zend_sprintf(char *buffer, const char *format, ...);
++#ifdef __cplusplus
++}
++#endif
+ #else
+ # define zend_sprintf sprintf
+ #endif
 diff --git a/acinclude.m4 b/acinclude.m4
 index 168c465f8d..6c087d152f 100644
 --- a/acinclude.m4

--- a/Formula/amp-php@7.2.rb
+++ b/Formula/amp-php@7.2.rb
@@ -42,6 +42,13 @@ class AmpPhpAT72 < Formula
     # Ensure that libxml2 will be detected correctly in older MacOS
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
 
+    # Work around for building with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
+      ENV.append "LDFLAGS", "-lresolv"
+      inreplace "main/reentrancy.c", "readdir_r(dirp, entry)", "readdir_r(dirp, entry, result)"
+    end
+
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     # See https://github.com/Homebrew/homebrew-core/pull/61828/

--- a/Formula/amp-php@7.3.rb
+++ b/Formula/amp-php@7.3.rb
@@ -43,6 +43,13 @@ class AmpPhpAT73 < Formula
     # Ensure that libxml2 will be detected correctly in older MacOS
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
 
+    # Work around for building with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
+      ENV.append "LDFLAGS", "-lresolv"
+      inreplace "main/reentrancy.c", "readdir_r(dirp, entry)", "readdir_r(dirp, entry, result)"
+    end
+
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     # See https://github.com/Homebrew/homebrew-core/pull/61828/

--- a/Formula/amp-php@7.4.rb
+++ b/Formula/amp-php@7.4.rb
@@ -58,6 +58,12 @@ class AmpPhpAT74 < Formula
       ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
     end
 
+    # Work around for building with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
+      ENV.append "LDFLAGS", "-lresolv"
+    end
+
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     # See https://github.com/Homebrew/homebrew-core/pull/61828/

--- a/Formula/amp-php@8.0.rb
+++ b/Formula/amp-php@8.0.rb
@@ -63,6 +63,12 @@ class AmpPhpAT80 < Formula
       ENV["SDKROOT"] = MacOS.sdk_path
     end
 
+    # Work around for building with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
+      ENV.append "LDFLAGS", "-lresolv"
+    end
+
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@1.1"].opt_lib/"pkgconfig"
 
     # buildconf required due to system library linking bug patch


### PR DESCRIPTION
### Description
After upgrading to Xcode 15.3, compiling PHP versions was failing with similar errors to the following:
```shell
/private/tmp/amp-phpA7.4-20240411-15010-hkii4g/php-7.4.33/ext/pdo_dblib/dblib_stmt.c:560:2: error: incompatible function pointer types initializing 'pdo_stmt_get_col_data_func' (aka 'int (*)(struct _pdo_stmt_t *, int, char **, unsigned long *, int *)') with an expression of type 'int (pdo_stmt_t *, int, char **, zend_ulong *, int *)' (aka 'int (struct _pdo_stmt_t *, int, char **, unsigned long long *, int *)') [-Wincompatible-function-pointer-types]
        pdo_dblib_stmt_get_col,
        ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [ext/pdo_dblib/dblib_stmt.lo] Error 1
make: *** Waiting for unfinished jobs....
/private/tmp/amp-phpA7.4-20240411-15010-hkii4g/php-7.4.33/ext/pdo_odbc/odbc_stmt.c:889:2: error: incompatible function pointer types initializing 'pdo_stmt_get_col_data_func' (aka 'int (*)(struct _pdo_stmt_t *, int, char **, unsigned long *, int *)') with an expression of type 'int (pdo_stmt_t *, int, char **, zend_ulong *, int *)' (aka 'int (struct _pdo_stmt_t *, int, char **, unsigned long long *, int *)') [-Wincompatible-function-pointer-types]
        odbc_stmt_get_col,
        ^~~~~~~~~~~~~~~~~
1 error generated.
make: *** [ext/pdo_odbc/odbc_stmt.lo] Error 1
```
This PR adds build flag workarounds for all affected formulas, see https://github.com/shivammathur/homebrew-php/commit/0b91fd267d580b013957e600bef15c40cb035784