### PR TITLE
Use icu4c 75 WIP

### DIFF
--- a/Formula/amp-php@8.1.rb
+++ b/Formula/amp-php@8.1.rb
@@ -29,7 +29,7 @@ class AmpPhpAT81 < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "gmp"
-  depends_on "icu4c"
+  depends_on "icu4c@75"
   depends_on "jpeg"
   depends_on "krb5"
   depends_on "libffi"
@@ -60,6 +60,16 @@ class AmpPhpAT81 < Formula
   patch :DATA
 
   def install
+  
+   # Backport fix for libxml2 >= 2.13
+      # Ref: https://github.com/php/php-src/commit/67259e451d5d58b4842776c5696a66d74e157609
+      inreplace "ext/xml/compat.c",
+                "!= XML_PARSER_ENTITY_VALUE && parser->parser->instate != XML_PARSER_ATTRIBUTE_VALUE)",
+                "== XML_PARSER_CONTENT)"
+  
+      # Work around to support `icu4c` 75, which needs C++17.
+      ENV["ICU_CXXFLAGS"] = "-std=c++17"
+      
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra
       ENV["SDKROOT"] = MacOS.sdk_path


### PR DESCRIPTION
### Description

The PR updates icu4c to use icu4c@75 https://github.com/shivammathur/homebrew-php/pull/3234/files#diff-0c6175fb529992fd183f5b10fdd0fefdbbeb79f309fc5271500385c686dc55bcR72

This issue was noted when trying to switch to swoon from a pinpoint project DataConnectr

```
dyld[15232]: Library not loaded: /usr/local/opt/icu4c/lib/libicuio.74.dylib

  Referenced from: <0673C106-E20E-3E3C-AD53-A7E58387006B> /usr/local/Cellar/amp-php@8.1/8.1.5/bin/php

  Reason: tried: '/usr/local/opt/icu4c/lib/libicuio.74.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/icu4c/lib/libicuio.74.dylib' (no such file), '/usr/local/opt/icu4c/lib/libicuio.74.dylib' (no such file)

```
